### PR TITLE
Drop Laravel 11 support

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -7,7 +7,7 @@ This is the Laravel plugin for Saloon, to install it run the following command
 ```php
 composer require saloonphp/laravel-plugin "^4.0"
 ```
->Requires Laravel 9+ and PHP 8.1+
+>Requires Laravel 12+ and PHP 8.2+
 
 ### Documentation
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: ['11.*', '12.*', '13.*']
+        laravel: ['12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 13.*

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
     "homepage": "https://github.com/saloonphp/laravel-plugin",
     "require": {
         "php": "^8.2",
-        "illuminate/console": "^11.0 || ^12.39.0 || ^13.0",
-        "illuminate/support": "^11.0 || ^12.39.0 || ^13.0",
+        "illuminate/console": "^12.39.0 || ^13.0",
+        "illuminate/support": "^12.39.0 || ^13.0",
         "saloonphp/saloon": "^4.0",
-        "symfony/finder": "^6.4 || ^7.0 || ^8.0"
+        "symfony/finder": "^7.0 || ^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.48",
         "laravel/pulse": "^1.4",
         "laravel/telescope": "^5.16",
-        "orchestra/testbench": "^9.15 || ^10.7 || ^11.0",
+        "orchestra/testbench": "^10.7 || ^11.0",
         "pestphp/pest": "^3.0|^4.0",
         "phpstan/phpstan": "^1.10.57|^2.0.2"
     },


### PR DESCRIPTION
- Drop Laravel 11 now that it is out of security support (12 Mar 2026). Composer 2.9+ blocks those installs at resolution time, so the `11.*` CI jobs can no longer install `laravel/framework`.
- Support Laravel 12 and 13 only: tighten `illuminate/console` and `illuminate/support` to `^12.39.0 || ^13.0`, drop `symfony/finder` `^6.4`, and drop Orchestra Testbench 9.
- Remove Laravel 11 from the test matrix and update the README requirements to Laravel 12+ / PHP 8.2+.